### PR TITLE
Add DummyPecService implementation and related tests

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,1 +1,2 @@
 lombok.addLombokGeneratedAnnotation = true
+lombok.log.custom.declaration = it.pagopa.pn.commons.log.PnLogger.getLogger(NAME)

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,7 @@
 
 	</dependencies>
 
+
 	<build>
 		<plugins>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -39,13 +39,13 @@
 		<dependency>
 			<groupId>it.pagopa.pn</groupId>
 			<artifactId>pn-commons</artifactId>
-			<version>2.2.4</version>
+			<version>2.6.0</version>
 		</dependency>
 
 		<dependency>
 			<groupId>it.pagopa.pn</groupId>
 			<artifactId>pn-servizifiduciari-spapi</artifactId>
-			<version>2.6.0</version>
+			<version>1.0.0</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -15,8 +15,8 @@
 		<connection>${git.conn}</connection>
 		<developerConnection>${git.devConn}</developerConnection>
 		<url>${git.url}</url>
-	  <tag>HEAD</tag>
-  </scm>
+		<tag>HEAD</tag>
+	</scm>
 	<properties>
 		<java.version>11</java.version>
 		<awspring.version>2.3.2</awspring.version>
@@ -35,12 +35,6 @@
 	</dependencyManagement>
 
 	<dependencies>
-
-		<dependency>
-			<groupId>it.pagopa.pn</groupId>
-			<artifactId>pn-commons</artifactId>
-			<version>2.6.0</version>
-		</dependency>
 
 		<dependency>
 			<groupId>it.pagopa.pn</groupId>
@@ -71,7 +65,7 @@
 			<artifactId>lombok</artifactId>
 			<scope>provided</scope>
 		</dependency>
-		
+
 		<dependency>
 			<groupId>net.logstash.logback</groupId>
 			<artifactId>logstash-logback-encoder</artifactId>
@@ -111,7 +105,7 @@
 				<groupId>org.openapitools</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
 				<version>5.4.0</version>
-				<executions>					
+				<executions>
 					<execution>
 						<id>generate-mandate-server</id>
 						<goals>
@@ -121,29 +115,29 @@
 						<configuration>
 							<inputSpec>${project.basedir}/docs/openapi/pn-template.yaml</inputSpec>
 							<generatorName>spring</generatorName>
-              				<library>spring-boot</library>
+							<library>spring-boot</library>
 							<generateApiDocumentation>false</generateApiDocumentation>
 							<generateApiTests>false</generateApiTests>
 							<generateModelTests>false</generateModelTests>
 							<configOptions>
-							<dateLibrary>java11</dateLibrary>
-							<delegatePattern>true</delegatePattern>
-							<interfaceOnly>true</interfaceOnly>
-							<annotationLibrary>none</annotationLibrary>
-							<documentationProvider>source</documentationProvider>
-							<openApiNullable>false</openApiNullable>
-							<reactive>true</reactive>
-							<skipDefaultInterface>false</skipDefaultInterface>
-							<useTags>true</useTags>
-							<basePackage>${project.groupId}.template.rest.v1</basePackage>
-							<modelPackage>${project.groupId}.template.rest.v1.dto</modelPackage>
-							<apiPackage>${project.groupId}.template.rest.v1.api</apiPackage>
-							<configPackage>${project.groupId}.template.rest.v1.config</configPackage>
-							</configOptions>				
+								<dateLibrary>java11</dateLibrary>
+								<delegatePattern>true</delegatePattern>
+								<interfaceOnly>true</interfaceOnly>
+								<annotationLibrary>none</annotationLibrary>
+								<documentationProvider>source</documentationProvider>
+								<openApiNullable>false</openApiNullable>
+								<reactive>true</reactive>
+								<skipDefaultInterface>false</skipDefaultInterface>
+								<useTags>true</useTags>
+								<basePackage>${project.groupId}.template.rest.v1</basePackage>
+								<modelPackage>${project.groupId}.template.rest.v1.dto</modelPackage>
+								<apiPackage>${project.groupId}.template.rest.v1.api</apiPackage>
+								<configPackage>${project.groupId}.template.rest.v1.config</configPackage>
+							</configOptions>
 						</configuration>
 					</execution>
 				</executions>
-			</plugin>			 		 
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -43,11 +43,28 @@
 		</dependency>
 
 		<dependency>
+			<groupId>it.pagopa.pn</groupId>
+			<artifactId>pn-servizifiduciari-spapi</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.sun.mail</groupId>
+			<artifactId>jakarta.mail</artifactId>
+			<version>2.0.1</version>
+		</dependency>
+
+		<dependency>
+			<groupId>com.sun.activation</groupId>
+			<artifactId>jakarta.activation</artifactId>
+			<version>2.0.1</version>
+		</dependency>
+
+		<dependency>
 			<groupId>io.swagger</groupId>
 			<artifactId>swagger-annotations</artifactId>
 			<version>1.6.5</version>
 		</dependency>
-
 
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>it.pagopa.pn</groupId>
 		<artifactId>pn-parent</artifactId>
-		<version>1.0.0</version>
+		<version>2.1.1</version>
 		<relativePath />
 	</parent>
 	<artifactId>pn-ec-dummy-pec</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 		<tag>HEAD</tag>
 	</scm>
 	<properties>
-		<java.version>11</java.version>
+		<java.version>17</java.version>
 		<awspring.version>2.3.2</awspring.version>
 	</properties>
 
@@ -81,6 +81,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>jakarta.mail</groupId>
+			<artifactId>jakarta.mail-api</artifactId>
 		</dependency>
 
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -39,13 +39,13 @@
 		<dependency>
 			<groupId>it.pagopa.pn</groupId>
 			<artifactId>pn-commons</artifactId>
-			<version>1.0.0</version>
+			<version>2.2.4</version>
 		</dependency>
 
 		<dependency>
 			<groupId>it.pagopa.pn</groupId>
 			<artifactId>pn-servizifiduciari-spapi</artifactId>
-			<version>1.0.0</version>
+			<version>2.6.0</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,9 @@
 		<version>1.0.0</version>
 		<relativePath />
 	</parent>
-	<artifactId>pn-template-ms-be</artifactId>
+	<artifactId>pn-ec-dummy-pec</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
-	<name>pn-template-ms-be</name>
+	<name>pn-ec-dummy-pec</name>
 	<description>A template for a PN Backend Microservice</description>
 	<scm>
 		<connection>${git.conn}</connection>

--- a/src/main/java/it/pagopa/pn/template/dto/PecInfo.java
+++ b/src/main/java/it/pagopa/pn/template/dto/PecInfo.java
@@ -1,0 +1,65 @@
+package it.pagopa.pn.template.dto;
+
+import it.pagopa.pn.template.type.PecType;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.util.Map;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Data
+@Builder
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class PecInfo {
+
+    String messageId;
+    String receiverAddress;
+    String subject;
+    String from;
+    String replyTo;
+    PecType pecType;
+    Map<String, String> errorMap;
+    boolean read;
+
+    public PecInfo messageId(String messageId) {
+        this.messageId = messageId;
+        return this;
+    }
+
+    public PecInfo receiverAddress(String receiverAddress) {
+        this.receiverAddress = receiverAddress;
+        return this;
+    }
+
+    public PecInfo subject(String subject) {
+        this.subject = subject;
+        return this;
+    }
+
+    public PecInfo from(String from) {
+        this.from = from;
+        return this;
+    }
+
+    public PecInfo replyTo(String replyTo) {
+        this.replyTo = replyTo;
+        return this;
+    }
+
+    public PecInfo pecType(PecType pecType) {
+        this.pecType = pecType;
+        return this;
+    }
+
+    public PecInfo read(boolean read) {
+        this.read = read;
+        return this;
+    }
+
+    public PecInfo errorCodes(Map<String, String> errorMap) {
+        this.errorMap = errorMap;
+        return this;
+    }
+
+}

--- a/src/main/java/it/pagopa/pn/template/service/DummyPecService.java
+++ b/src/main/java/it/pagopa/pn/template/service/DummyPecService.java
@@ -1,0 +1,141 @@
+package it.pagopa.pn.template.service;
+
+import it.pagopa.pn.library.pec.pojo.PnGetMessagesResponse;
+import it.pagopa.pn.library.pec.pojo.PnListOfMessages;
+import it.pagopa.pn.library.pec.service.PnPecService;
+import it.pagopa.pn.template.dto.PecInfo;
+import it.pagopa.pn.template.type.PecType;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Getter
+@RequiredArgsConstructor
+@Service
+public class DummyPecService implements PnPecService {
+    private final ConcurrentHashMap<String, PecInfo> pecMap = new ConcurrentHashMap<>();
+    private final DummyPecServiceUtil dummyPecServiceUtil;
+
+    @Override
+    public Mono<String> sendMail(byte[] message) {
+        return Mono.fromCallable(() -> {
+            // parse message
+            MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()), new ByteArrayInputStream(message));
+
+            // get message info
+            String subject = mimeMessage.getSubject();
+            String from = mimeMessage.getFrom()[0].toString();
+            String replyTo = (mimeMessage.getReplyTo() != null && mimeMessage.getReplyTo().length > 0)
+                    ? mimeMessage.getReplyTo()[0].toString() : null;
+            String receiverAddress = mimeMessage.getAllRecipients()[0].toString();
+            String originalMessageId = mimeMessage.getMessageID();
+
+            // build unique id for acceptance and delivery
+            String acceptanceMessageId = UUID.randomUUID().toString();
+            String deliveryMessageId = UUID.randomUUID().toString();
+
+            PecInfo acceptanceInfo = PecInfo.builder()
+                                            .messageId(acceptanceMessageId)
+                                            .receiverAddress(receiverAddress)
+                                            .subject(subject)
+                                            .from(from)
+                                            .replyTo(replyTo)
+                                            .pecType(PecType.ACCETTAZIONE)
+                                            .errorMap(Map.of()) // no default error
+                                            .read(false)
+                                            .build();
+
+            PecInfo deliveryInfo = PecInfo.builder()
+                                          .messageId(deliveryMessageId)
+                                          .receiverAddress(receiverAddress)
+                                          .subject(subject)
+                                          .from(from)
+                                          .replyTo(replyTo)
+                                          .pecType(PecType.CONSEGNA)
+                                          .errorMap(Map.of()) // no default error
+                                          .read(false)
+                                          .build();
+
+            // add message in thread-safe object
+            pecMap.put(acceptanceMessageId, acceptanceInfo);
+            pecMap.put(deliveryMessageId, deliveryInfo);
+
+            return originalMessageId;
+        }).delayElement(java.time.Duration.ofMillis(dummyPecServiceUtil.calculateRandomDelay()));
+    }
+
+    @Override
+    public Mono<PnGetMessagesResponse> getUnreadMessages(int limit) {
+        return Mono.fromCallable(() -> {
+            if (limit <= 0) {
+                throw new IllegalArgumentException("Limit must be greater than 0");
+            }
+
+            // Filtra i messaggi non letti
+            var unreadMessages = pecMap.values().stream()
+                                       .filter(pecInfo -> !pecInfo.isRead())
+                                       .limit(limit)
+                                       .toList();
+
+            // Costruisci la lista di byte[] da PecInfo
+            List<byte[]> messageBytes = unreadMessages.stream()
+                                                      .map(dummyPecServiceUtil::convertPecInfoToBytes)
+                                                      .toList();
+
+            // Crea un oggetto PnListOfMessages
+            PnListOfMessages pnListOfMessages = new PnListOfMessages(messageBytes);
+
+            // Restituisci la risposta PnGetMessagesResponse
+            return new PnGetMessagesResponse(pnListOfMessages, unreadMessages.size());
+        }).delayElement(java.time.Duration.ofMillis(dummyPecServiceUtil.calculateRandomDelay()));
+    }
+
+    @Override
+    public Mono<Void> markMessageAsRead(String messageID) {
+        return Mono.fromRunnable(() -> {
+            if (messageID == null || messageID.isEmpty()) {
+                throw new IllegalArgumentException("Message ID cannot be null or empty");
+            }
+
+            PecInfo message = pecMap.get(messageID);
+
+            if (message == null) {
+                throw new IllegalArgumentException("Message with ID " + messageID + " not found");
+            }
+
+            message.setRead(true);
+        }).delayElement(java.time.Duration.ofMillis(dummyPecServiceUtil.calculateRandomDelay())).then();
+    }
+
+
+    @Override
+    public Mono<Integer> getMessageCount() {
+        return Mono.fromSupplier(pecMap::size)
+                   .delayElement(java.time.Duration.ofMillis(dummyPecServiceUtil.calculateRandomDelay()));
+    }
+
+    @Override
+    public Mono<Void> deleteMessage(String messageID) {
+        return Mono.fromRunnable(() -> {
+            if (messageID == null || messageID.isEmpty()) {
+                throw new IllegalArgumentException("Message ID cannot be null or empty");
+            }
+
+            PecInfo removedMessage = pecMap.remove(messageID);
+
+            if (removedMessage == null) {
+                throw new IllegalArgumentException("Message with ID " + messageID + " not found");
+            }
+        }).delayElement(java.time.Duration.ofMillis(dummyPecServiceUtil.calculateRandomDelay())).then();
+    }
+}

--- a/src/main/java/it/pagopa/pn/template/service/DummyPecService.java
+++ b/src/main/java/it/pagopa/pn/template/service/DummyPecService.java
@@ -21,6 +21,8 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static it.pagopa.pn.template.service.DummyPecServiceUtil.DUMMY_PATTERN_STRING;
+
 @Getter
 @RequiredArgsConstructor
 @Service
@@ -53,8 +55,8 @@ public class DummyPecService implements PnPecService {
                         subject, from, replyTo, receiverAddress, originalMessageId);
 
                // build unique id for acceptance and delivery
-               String acceptanceMessageId = UUID.randomUUID().toString();
-               String deliveryMessageId = UUID.randomUUID().toString();
+               String acceptanceMessageId = UUID.randomUUID() + DUMMY_PATTERN_STRING;
+               String deliveryMessageId = UUID.randomUUID() + DUMMY_PATTERN_STRING;
 
                PecInfo acceptanceInfo = PecInfo.builder()
                                                .messageId(messageID)

--- a/src/main/java/it/pagopa/pn/template/service/DummyPecService.java
+++ b/src/main/java/it/pagopa/pn/template/service/DummyPecService.java
@@ -7,6 +7,7 @@ import it.pagopa.pn.template.dto.PecInfo;
 import it.pagopa.pn.template.type.PecType;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
+import lombok.CustomLog;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,90 +19,114 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 
 @Getter
 @RequiredArgsConstructor
 @Service
+@CustomLog
 public class DummyPecService implements PnPecService {
     private final ConcurrentHashMap<String, PecInfo> pecMap = new ConcurrentHashMap<>();
     private final DummyPecServiceUtil dummyPecServiceUtil;
 
     @Override
     public Mono<String> sendMail(byte[] message) {
+        log.logStartingProcess("Send mail starting...");
+        AtomicReference<String> originalMessageIdRef = new AtomicReference<>();
+
         return Mono.fromCallable(() -> {
-            // parse message
-            MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()), new ByteArrayInputStream(message));
+               // parse message
+               MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()), new ByteArrayInputStream(message));
 
-            // get message info
-            String subject = mimeMessage.getSubject();
-            String from = mimeMessage.getFrom()[0].toString();
-            String replyTo = (mimeMessage.getReplyTo() != null && mimeMessage.getReplyTo().length > 0)
-                    ? mimeMessage.getReplyTo()[0].toString() : null;
-            String receiverAddress = mimeMessage.getAllRecipients()[0].toString();
-            String originalMessageId = mimeMessage.getMessageID();
+               // get message info
+               String subject = mimeMessage.getSubject();
+               String from = mimeMessage.getFrom()[0].toString();
+               String replyTo = (mimeMessage.getReplyTo() != null &&
+                                 mimeMessage.getReplyTo().length > 0) ? mimeMessage.getReplyTo()[0].toString() : null;
+               String receiverAddress = mimeMessage.getAllRecipients()[0].toString();
+               String originalMessageId = mimeMessage.getMessageID();
 
-            // build unique id for acceptance and delivery
-            String acceptanceMessageId = UUID.randomUUID().toString();
-            String deliveryMessageId = UUID.randomUUID().toString();
+               originalMessageIdRef.set(originalMessageId);
 
-            PecInfo acceptanceInfo = PecInfo.builder()
-                                            .messageId(acceptanceMessageId)
-                                            .receiverAddress(receiverAddress)
-                                            .subject(subject)
-                                            .from(from)
-                                            .replyTo(replyTo)
-                                            .pecType(PecType.ACCETTAZIONE)
-                                            .errorMap(Map.of()) // no default error
-                                            .read(false)
-                                            .build();
+               log.info("Received message with subject: {}, from: {}, replyTo: {}, receiverAddress: {}, originalMessageId: {}",
+                        subject, from, replyTo, receiverAddress, originalMessageId);
 
-            PecInfo deliveryInfo = PecInfo.builder()
-                                          .messageId(deliveryMessageId)
-                                          .receiverAddress(receiverAddress)
-                                          .subject(subject)
-                                          .from(from)
-                                          .replyTo(replyTo)
-                                          .pecType(PecType.CONSEGNA)
-                                          .errorMap(Map.of()) // no default error
-                                          .read(false)
-                                          .build();
+               // build unique id for acceptance and delivery
+               String acceptanceMessageId = UUID.randomUUID().toString();
+               String deliveryMessageId = UUID.randomUUID().toString();
 
-            // add message in thread-safe object
-            pecMap.put(acceptanceMessageId, acceptanceInfo);
-            pecMap.put(deliveryMessageId, deliveryInfo);
+               PecInfo acceptanceInfo = PecInfo.builder()
+                                               .messageId(acceptanceMessageId)
+                                               .receiverAddress(receiverAddress)
+                                               .subject(subject)
+                                               .from(from)
+                                               .replyTo(replyTo)
+                                               .pecType(PecType.ACCETTAZIONE)
+                                               .errorMap(Map.of()) // no default error
+                                               .read(false)
+                                               .build();
 
-            return originalMessageId;
-        }).delayElement(java.time.Duration.ofMillis(dummyPecServiceUtil.calculateRandomDelay()));
+               PecInfo deliveryInfo = PecInfo.builder()
+                                             .messageId(deliveryMessageId)
+                                             .receiverAddress(receiverAddress)
+                                             .subject(subject)
+                                             .from(from)
+                                             .replyTo(replyTo)
+                                             .pecType(PecType.CONSEGNA)
+                                             .errorMap(Map.of()) // no default error
+                                             .read(false)
+                                             .build();
+
+               // add message in thread-safe object
+               pecMap.put(acceptanceMessageId, acceptanceInfo);
+               pecMap.put(deliveryMessageId, deliveryInfo);
+
+               return originalMessageId;
+       })
+       .doOnSuccess(messageId -> log.logEndingProcess("Send mail success, message id: " + messageId))
+       .doOnError(throwable -> log.logEndingProcess("Send mail error, message id: " + originalMessageIdRef.get(), false, throwable.getMessage()))
+       .delayElement(java.time.Duration.ofMillis(dummyPecServiceUtil.calculateRandomDelay()));
     }
 
     @Override
     public Mono<PnGetMessagesResponse> getUnreadMessages(int limit) {
+        log.logStartingProcess("Get unread messages starting...");
+        log.info("Limit: {}", limit);
+        StringBuilder unreadMessagesLog = new StringBuilder();
+
         return Mono.fromCallable(() -> {
-            if (limit <= 0) {
-                throw new IllegalArgumentException("Limit must be greater than 0");
-            }
+                       if (limit <= 0) {
+                           throw new IllegalArgumentException("Limit must be greater than 0");
+                       }
 
-            // Filtra i messaggi non letti
-            var unreadMessages = pecMap.values().stream()
-                                       .filter(pecInfo -> !pecInfo.isRead())
-                                       .limit(limit)
-                                       .toList();
+                       // Filtra i messaggi non letti
+                       var unreadMessages = pecMap.values().stream().filter(pecInfo -> !pecInfo.isRead()).limit(limit).toList();
 
-            // Costruisci la lista di byte[] da PecInfo
-            List<byte[]> messageBytes = unreadMessages.stream()
-                                                      .map(dummyPecServiceUtil::convertPecInfoToBytes)
-                                                      .toList();
+                       unreadMessages.stream()
+                                     .map(PecInfo::getMessageId)
+                                     .toList()
+                                     .forEach(messageId -> unreadMessagesLog.append(messageId).append(", "));
 
-            // Crea un oggetto PnListOfMessages
-            PnListOfMessages pnListOfMessages = new PnListOfMessages(messageBytes);
+                       // Costruisci la lista di byte[] da PecInfo
+                       List<byte[]> messageBytes = unreadMessages.stream().map(dummyPecServiceUtil::convertPecInfoToBytes).toList();
 
-            // Restituisci la risposta PnGetMessagesResponse
-            return new PnGetMessagesResponse(pnListOfMessages, unreadMessages.size());
-        }).delayElement(java.time.Duration.ofMillis(dummyPecServiceUtil.calculateRandomDelay()));
+                       // Crea un oggetto PnListOfMessages
+                       PnListOfMessages pnListOfMessages = new PnListOfMessages(messageBytes);
+
+                       // Restituisci la risposta PnGetMessagesResponse
+                       return new PnGetMessagesResponse(pnListOfMessages, unreadMessages.size());
+                   })
+       .doOnSuccess(result -> log.logEndingProcess("Get unread messages success, message ids: " + unreadMessagesLog))
+       .doOnError(throwable -> log.logEndingProcess("Get unread messages error, message ids: " + unreadMessagesLog, false, throwable.getMessage()))
+       .delayElement(java.time.Duration.ofMillis(dummyPecServiceUtil.calculateRandomDelay()));
     }
 
     @Override
     public Mono<Void> markMessageAsRead(String messageID) {
+        log.logStartingProcess("Mark message as read starting...");
+        log.info("Message ID: {}", messageID);
+        AtomicReference<String> originalMessageIdRef = new AtomicReference<>(messageID);
+
         return Mono.fromRunnable(() -> {
             if (messageID == null || messageID.isEmpty()) {
                 throw new IllegalArgumentException("Message ID cannot be null or empty");
@@ -114,18 +139,29 @@ public class DummyPecService implements PnPecService {
             }
 
             message.setRead(true);
-        }).delayElement(java.time.Duration.ofMillis(dummyPecServiceUtil.calculateRandomDelay())).then();
+        })
+       .doOnSuccess(result -> log.logEndingProcess("Mark message as read success with message id: " + originalMessageIdRef.get()))
+       .doOnError(throwable -> log.logEndingProcess("Mark message as read error with message id: " + originalMessageIdRef.get(),
+                                                    false, throwable.getMessage()))
+       .delayElement(java.time.Duration.ofMillis(dummyPecServiceUtil.calculateRandomDelay())).then();
     }
 
 
     @Override
     public Mono<Integer> getMessageCount() {
+        log.logStartingProcess("Get message count starting...");
+
         return Mono.fromSupplier(pecMap::size)
-                   .delayElement(java.time.Duration.ofMillis(dummyPecServiceUtil.calculateRandomDelay()));
+           .doOnSuccess(result -> log.logEndingProcess("Get message count success, value: " + pecMap.size()))
+           .doOnError(throwable -> log.logEndingProcess("Get message count error, value: " + pecMap.size(), false, throwable.getMessage()))
+           .delayElement(java.time.Duration.ofMillis(dummyPecServiceUtil.calculateRandomDelay()));
     }
 
     @Override
     public Mono<Void> deleteMessage(String messageID) {
+        log.logStartingProcess("Delete message starting...");
+        log.info("Message ID: {}", messageID);
+
         return Mono.fromRunnable(() -> {
             if (messageID == null || messageID.isEmpty()) {
                 throw new IllegalArgumentException("Message ID cannot be null or empty");
@@ -136,6 +172,9 @@ public class DummyPecService implements PnPecService {
             if (removedMessage == null) {
                 throw new IllegalArgumentException("Message with ID " + messageID + " not found");
             }
-        }).delayElement(java.time.Duration.ofMillis(dummyPecServiceUtil.calculateRandomDelay())).then();
+        })
+        .doOnSuccess(result -> log.logEndingProcess("Delete message success, message id: " + messageID))
+        .doOnError(throwable -> log.logEndingProcess("Delete message  error, message id: " + messageID, false, throwable.getMessage()))
+        .delayElement(java.time.Duration.ofMillis(dummyPecServiceUtil.calculateRandomDelay())).then();
     }
 }

--- a/src/main/java/it/pagopa/pn/template/service/DummyPecService.java
+++ b/src/main/java/it/pagopa/pn/template/service/DummyPecService.java
@@ -39,6 +39,7 @@ public class DummyPecService implements PnPecService {
                MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()), new ByteArrayInputStream(message));
 
                // get message info
+               String messageID = mimeMessage.getMessageID();
                String subject = mimeMessage.getSubject();
                String from = mimeMessage.getFrom()[0].toString();
                String replyTo = (mimeMessage.getReplyTo() != null &&
@@ -56,7 +57,7 @@ public class DummyPecService implements PnPecService {
                String deliveryMessageId = UUID.randomUUID().toString();
 
                PecInfo acceptanceInfo = PecInfo.builder()
-                                               .messageId(acceptanceMessageId)
+                                               .messageId(messageID)
                                                .receiverAddress(receiverAddress)
                                                .subject(subject)
                                                .from(from)
@@ -67,7 +68,7 @@ public class DummyPecService implements PnPecService {
                                                .build();
 
                PecInfo deliveryInfo = PecInfo.builder()
-                                             .messageId(deliveryMessageId)
+                                             .messageId(messageID)
                                              .receiverAddress(receiverAddress)
                                              .subject(subject)
                                              .from(from)

--- a/src/main/java/it/pagopa/pn/template/service/DummyPecService.java
+++ b/src/main/java/it/pagopa/pn/template/service/DummyPecService.java
@@ -101,10 +101,10 @@ public class DummyPecService implements PnPecService {
                        }
 
                        // Filtra i messaggi non letti
-                       var unreadMessages = pecMap.values().stream().filter(pecInfo -> !pecInfo.isRead()).limit(limit).toList();
+                       var unreadMessages = pecMap.entrySet().stream().filter(entry -> !entry.getValue().isRead()).limit(limit).toList();
 
                        unreadMessages.stream()
-                                     .map(PecInfo::getMessageId)
+                                     .map(entry -> entry.getValue().getMessageId())
                                      .toList()
                                      .forEach(messageId -> unreadMessagesLog.append(messageId).append(", "));
 

--- a/src/main/java/it/pagopa/pn/template/service/DummyPecServiceUtil.java
+++ b/src/main/java/it/pagopa/pn/template/service/DummyPecServiceUtil.java
@@ -16,11 +16,12 @@ import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
+import static jakarta.mail.Message.RecipientType.TO;
+
 @Service
 public class DummyPecServiceUtil {
     @Value("${dummy.pec.min-delay-ms:100}")
     private long minDelayMs;
-
     @Value("${dummy.pec.max-delay-ms:500}")
     private long maxDelayMs;
 
@@ -39,8 +40,7 @@ public class DummyPecServiceUtil {
             mimeMessage.setFrom(pecInfo.getFrom() != null ? pecInfo.getFrom() : "unknown@domain.com");
 
             if (pecInfo.getReceiverAddress() != null) {
-                mimeMessage.addRecipient(MimeMessage.RecipientType.TO,
-                                         new jakarta.mail.internet.InternetAddress(pecInfo.getReceiverAddress()));
+                mimeMessage.addRecipient(TO, new jakarta.mail.internet.InternetAddress(pecInfo.getReceiverAddress()));
             }
 
             // Crea il contenuto del messaggio
@@ -48,16 +48,7 @@ public class DummyPecServiceUtil {
             textPart.setText("Questo è un messaggio di esempio.", "UTF-8");
 
             // Genera il contenuto del daticert.xml
-            StringBuffer datiCertXml = PecUtils.generateDaticertConsegna(
-                    pecInfo.getFrom(),
-                    pecInfo.getReceiverAddress(),
-                    pecInfo.getReplyTo(),
-                    pecInfo.getSubject(),
-                    "mock-pec",
-                    PecUtils.getCurrentDate(),
-                    PecUtils.getCurrentTime(),
-                    pecInfo.getMessageId()
-                                                                  );
+            StringBuilder datiCertXml = PecUtils.generateDaticert(pecInfo, "mock-pec", PecUtils.getCurrentDate(), PecUtils.getCurrentTime());
 
             // Crea la parte del messaggio per daticert.xml
             var datiCertPart = new MimeBodyPart();

--- a/src/main/java/it/pagopa/pn/template/service/DummyPecServiceUtil.java
+++ b/src/main/java/it/pagopa/pn/template/service/DummyPecServiceUtil.java
@@ -1,0 +1,47 @@
+package it.pagopa.pn.template.service;
+
+import it.pagopa.pn.template.dto.PecInfo;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Properties;
+
+@Service
+public class DummyPecServiceUtil {
+    @Value("${dummy.pec.min-delay-ms:100}")
+    private long minDelayMs;
+
+    @Value("${dummy.pec.max-delay-ms:500}")
+    private long maxDelayMs;
+
+    public long calculateRandomDelay() {
+        return minDelayMs + (long) (Math.random() * (maxDelayMs - minDelayMs));
+    }
+
+    byte[] convertPecInfoToBytes(PecInfo pecInfo) {
+        try {
+            Session session = Session.getDefaultInstance(new Properties());
+
+            MimeMessage mimeMessage = new MimeMessage(session);
+            mimeMessage.setSubject(pecInfo.getSubject() != null ? pecInfo.getSubject() : "No Subject");
+            mimeMessage.setFrom(pecInfo.getFrom() != null ? pecInfo.getFrom() : "unknown@domain.com");
+
+            if (pecInfo.getReceiverAddress() != null) {
+                mimeMessage.addRecipient(MimeMessage.RecipientType.TO,
+                                         new jakarta.mail.internet.InternetAddress(pecInfo.getReceiverAddress()));
+            }
+
+            mimeMessage.setText("Questo è un messaggio di esempio.");
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            mimeMessage.writeTo(outputStream);
+
+            return outputStream.toByteArray();
+        } catch (Exception e) {
+            throw new RuntimeException("Error converting PecInfo to byte[]", e);
+        }
+    }
+
+}

--- a/src/main/java/it/pagopa/pn/template/service/DummyPecServiceUtil.java
+++ b/src/main/java/it/pagopa/pn/template/service/DummyPecServiceUtil.java
@@ -27,6 +27,7 @@ public class DummyPecServiceUtil {
     private long minDelayMs;
     @Value("${dummy.pec.max-delay-ms:500}")
     private long maxDelayMs;
+    public static final String DUMMY_PATTERN_STRING = "@pec.dummy.it";
 
     public long calculateRandomDelay() {
         return minDelayMs + (long) (Math.random() * (maxDelayMs - minDelayMs));

--- a/src/main/java/it/pagopa/pn/template/service/DummyPecServiceUtil.java
+++ b/src/main/java/it/pagopa/pn/template/service/DummyPecServiceUtil.java
@@ -9,16 +9,19 @@ import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeMultipart;
 import jakarta.mail.util.ByteArrayDataSource;
+import lombok.CustomLog;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import java.util.Properties;
 
 import static jakarta.mail.Message.RecipientType.TO;
 
 @Service
+@CustomLog
 public class DummyPecServiceUtil {
     @Value("${dummy.pec.min-delay-ms:100}")
     private long minDelayMs;
@@ -29,8 +32,11 @@ public class DummyPecServiceUtil {
         return minDelayMs + (long) (Math.random() * (maxDelayMs - minDelayMs));
     }
 
-    byte[] convertPecInfoToBytes(PecInfo pecInfo) {
+    byte[] convertPecInfoToBytes(Map.Entry<String, PecInfo> entry) {
         try {
+            String messageID = entry.getKey();
+            PecInfo pecInfo = entry.getValue();
+
             // Creazione della sessione MIME
             Session session = Session.getDefaultInstance(new Properties());
             MimeMessage mimeMessage = new MimeMessage(session);
@@ -67,6 +73,9 @@ public class DummyPecServiceUtil {
 
             // Converte il messaggio MIME in byte array
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+            mimeMessage.saveChanges();
+            mimeMessage.setHeader("Message-ID", messageID);
             mimeMessage.writeTo(outputStream);
 
             return outputStream.toByteArray();

--- a/src/main/java/it/pagopa/pn/template/type/PecType.java
+++ b/src/main/java/it/pagopa/pn/template/type/PecType.java
@@ -1,0 +1,6 @@
+package it.pagopa.pn.template.type;
+
+public enum PecType {
+    CONSEGNA,
+    ACCETTAZIONE;
+}

--- a/src/main/java/it/pagopa/pn/template/util/PecUtils.java
+++ b/src/main/java/it/pagopa/pn/template/util/PecUtils.java
@@ -1,0 +1,58 @@
+package it.pagopa.pn.template.util;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.text.SimpleDateFormat;
+import java.util.Base64;
+import java.util.Calendar;
+import java.util.Random;
+
+@Slf4j
+public class PecUtils {
+    public static String generateRandomString(int length) {
+        Random random = new Random();
+
+        // Use the nextBytes() method to generate a random sequence of bytes.
+        byte[] bytes = new byte[length];
+        random.nextBytes(bytes);
+
+        // Convert the bytes to a string using the Base64 encoding.
+        return Base64.getEncoder().encodeToString(bytes);
+    }
+
+    public static StringBuffer generateDaticertConsegna(String from, String receiver, String replyTo, String subject, String gestoreMittente, String data, String orario, String messageId){
+
+        //Costruzione del daticert
+        StringBuffer stringBufferContent = new StringBuffer();
+        stringBufferContent.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");//popolare con daticert su note
+        stringBufferContent.append("<postacert tipo=\"avvenuta-consegna\" errore=\"nessuno\">");
+        stringBufferContent.append("<intestazione>");
+        stringBufferContent.append("<mittente>").append(from).append("</mittente>"); //mittente dell'email, sta nella mappa
+        stringBufferContent.append("<destinatari tipo=\"certificato\">").append(receiver).append("</destinatari>"); //destinatario dell'email, sta nella mappa
+        stringBufferContent.append("<risposte>").append(replyTo).append("</risposte>"); //nel messaggio che uso per popolare la mappa c'è un reply-to
+        stringBufferContent.append("<oggetto>").append(subject).append("</oggetto>"); //oggetto dell'email, sta nella mappa
+        stringBufferContent.append("</intestazione>");
+        stringBufferContent.append("<dati>");
+        stringBufferContent.append("<gestore-emittente>").append(gestoreMittente).append("</gestore-emittente>"); //da inventare = "mock-pec" costante
+        stringBufferContent.append("<data zona=\"+0200\">"); //lasciare così
+        stringBufferContent.append("<giorno>").append(data).append("</giorno>"); //impostare in base all'ora
+        stringBufferContent.append("<ora>").append(orario).append("</ora>"); //impostare in base all'ora
+        stringBufferContent.append("</data>");
+        stringBufferContent.append("<identificativo>").append(generateRandomString(64)).append("</identificativo>"); //stringa random 64 caratteri
+        stringBufferContent.append("<msgid>").append("&lt;").append(messageId).append("&gt;").append("</msgid>"); //msgid della mappa, nella forma url encoded. fare url encode della stringa
+        stringBufferContent.append("<ricevuta tipo=\"completa\" />");
+        stringBufferContent.append("<consegna>").append(receiver).append("</consegna>");
+        stringBufferContent.append("</dati>");
+        stringBufferContent.append("</postacert>");
+
+        return stringBufferContent;
+    }
+
+    public static String getCurrentTime() {
+        return new SimpleDateFormat("HH:mm:ss").format(Calendar.getInstance().getTime());
+    }
+
+    public static String getCurrentDate() {
+        return new SimpleDateFormat("dd/MM/yyyy").format(Calendar.getInstance().getTime());
+    }
+}

--- a/src/main/java/it/pagopa/pn/template/util/PecUtils.java
+++ b/src/main/java/it/pagopa/pn/template/util/PecUtils.java
@@ -1,5 +1,7 @@
 package it.pagopa.pn.template.util;
 
+import it.pagopa.pn.template.dto.PecInfo;
+import it.pagopa.pn.template.type.PecType;
 import lombok.extern.slf4j.Slf4j;
 
 import java.text.SimpleDateFormat;
@@ -9,9 +11,12 @@ import java.util.Random;
 
 @Slf4j
 public class PecUtils {
-    public static String generateRandomString(int length) {
-        Random random = new Random();
+    private static final Random random = new Random();
 
+    private PecUtils() {
+        throw new IllegalStateException("PecUtils is a utility class");
+    }
+    public static String generateRandomString(int length) {
         // Use the nextBytes() method to generate a random sequence of bytes.
         byte[] bytes = new byte[length];
         random.nextBytes(bytes);
@@ -20,32 +25,37 @@ public class PecUtils {
         return Base64.getEncoder().encodeToString(bytes);
     }
 
-    public static StringBuffer generateDaticertConsegna(String from, String receiver, String replyTo, String subject, String gestoreMittente, String data, String orario, String messageId){
+    public static StringBuilder generateDaticert(PecInfo pecInfo, String gestoreMittente, String data, String orario){
+
+        boolean isAccettazione = pecInfo.getPecType().equals(PecType.ACCETTAZIONE);
+        String postacertType = isAccettazione ? "accettazione" : "avvenuta-consegna";
 
         //Costruzione del daticert
-        StringBuffer stringBufferContent = new StringBuffer();
-        stringBufferContent.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");//popolare con daticert su note
-        stringBufferContent.append("<postacert tipo=\"avvenuta-consegna\" errore=\"nessuno\">");
-        stringBufferContent.append("<intestazione>");
-        stringBufferContent.append("<mittente>").append(from).append("</mittente>"); //mittente dell'email, sta nella mappa
-        stringBufferContent.append("<destinatari tipo=\"certificato\">").append(receiver).append("</destinatari>"); //destinatario dell'email, sta nella mappa
-        stringBufferContent.append("<risposte>").append(replyTo).append("</risposte>"); //nel messaggio che uso per popolare la mappa c'è un reply-to
-        stringBufferContent.append("<oggetto>").append(subject).append("</oggetto>"); //oggetto dell'email, sta nella mappa
-        stringBufferContent.append("</intestazione>");
-        stringBufferContent.append("<dati>");
-        stringBufferContent.append("<gestore-emittente>").append(gestoreMittente).append("</gestore-emittente>"); //da inventare = "mock-pec" costante
-        stringBufferContent.append("<data zona=\"+0200\">"); //lasciare così
-        stringBufferContent.append("<giorno>").append(data).append("</giorno>"); //impostare in base all'ora
-        stringBufferContent.append("<ora>").append(orario).append("</ora>"); //impostare in base all'ora
-        stringBufferContent.append("</data>");
-        stringBufferContent.append("<identificativo>").append(generateRandomString(64)).append("</identificativo>"); //stringa random 64 caratteri
-        stringBufferContent.append("<msgid>").append("&lt;").append(messageId).append("&gt;").append("</msgid>"); //msgid della mappa, nella forma url encoded. fare url encode della stringa
-        stringBufferContent.append("<ricevuta tipo=\"completa\" />");
-        stringBufferContent.append("<consegna>").append(receiver).append("</consegna>");
-        stringBufferContent.append("</dati>");
-        stringBufferContent.append("</postacert>");
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");//popolare con daticert su note
+        stringBuilder.append("<postacert tipo=\"").append(postacertType).append("\" errore=\"nessuno\">");
+        stringBuilder.append("<intestazione>");
+        stringBuilder.append("<mittente>").append(pecInfo.getFrom()).append("</mittente>"); //mittente dell'email, sta nella mappa
+        stringBuilder.append("<destinatari tipo=\"certificato\">").append(pecInfo.getReceiverAddress()).append("</destinatari>"); //destinatario dell'email, sta nella mappa
+        stringBuilder.append("<risposte>").append(pecInfo.getReplyTo()).append("</risposte>"); //nel messaggio che uso per popolare la mappa c'è un reply-to
+        stringBuilder.append("<oggetto>").append(pecInfo.getSubject()).append("</oggetto>"); //oggetto dell'email, sta nella mappa
+        stringBuilder.append("</intestazione>");
+        stringBuilder.append("<dati>");
+        stringBuilder.append("<gestore-emittente>").append(gestoreMittente).append("</gestore-emittente>"); //da inventare = "mock-pec" costante
+        stringBuilder.append("<data zona=\"+0200\">"); //lasciare così
+        stringBuilder.append("<giorno>").append(data).append("</giorno>"); //impostare in base all'ora
+        stringBuilder.append("<ora>").append(orario).append("</ora>"); //impostare in base all'ora
+        stringBuilder.append("</data>");
+        stringBuilder.append("<identificativo>").append(generateRandomString(64)).append("</identificativo>"); //stringa random 64 caratteri
+        stringBuilder.append("<msgid>").append("&lt;").append(pecInfo.getMessageId()).append("&gt;").append("</msgid>"); //msgid della mappa, nella forma url encoded. fare url encode della stringa
+        if (!isAccettazione) {
+            stringBuilder.append("<ricevuta tipo=\"completa\" />");
+            stringBuilder.append("<consegna>").append(pecInfo.getReceiverAddress()).append("</consegna>");
+        }
+        stringBuilder.append("</dati>");
+        stringBuilder.append("</postacert>");
 
-        return stringBufferContent;
+        return stringBuilder;
     }
 
     public static String getCurrentTime() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,4 @@ logging.config=classpath:logback-base.xml
 
 pn.env.runtime=PROD
 spring.application.name=PN-TEMPLATE-MS-BE
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,4 +2,3 @@ logging.config=classpath:logback-base.xml
 
 pn.env.runtime=PROD
 spring.application.name=PN-TEMPLATE-MS-BE
-

--- a/src/main/resources/logback-base.xml
+++ b/src/main/resources/logback-base.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
+<configuration scan="true" scanPeriod="30 seconds" >
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%X{trace_id}] %highlight(%-5level) - %-4relative - [%thread] - %cyan(%logger{20}) - %red([%X{cx_id}]) - %msg %n</pattern>
+        </encoder>
+    </appender>
+    <root level="info">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>

--- a/src/test/java/it/pagopa/pn/template/service/DummyPecServiceDeleteMessageTest.java
+++ b/src/test/java/it/pagopa/pn/template/service/DummyPecServiceDeleteMessageTest.java
@@ -1,0 +1,43 @@
+package it.pagopa.pn.template.service;
+
+import it.pagopa.pn.template.dto.PecInfo;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import reactor.test.StepVerifier;
+
+@SpringBootTest(classes = DummyPecTestApplication.class)
+class DummyPecServiceDeleteMessageTest {
+    @Autowired
+    private DummyPecService dummyPecService;
+
+    @Test
+    void testDeleteMessage_ShouldDeleteExistingMessage() {
+        String messageID = "test-message-id";
+        dummyPecService.getPecMap().put(messageID, PecInfo.builder().messageId(messageID).build());
+
+        StepVerifier.create(dummyPecService.deleteMessage(messageID))
+                    .verifyComplete();
+
+        Assertions.assertNull(dummyPecService.getPecMap().get(messageID));
+    }
+
+    @Test
+    void testDeleteMessage_ShouldThrowExceptionForNullOrEmptyMessageID() {
+        StepVerifier.create(dummyPecService.deleteMessage(null))
+                    .expectError(IllegalArgumentException.class)
+                    .verify();
+
+        StepVerifier.create(dummyPecService.deleteMessage(""))
+                    .expectError(IllegalArgumentException.class)
+                    .verify();
+    }
+
+    @Test
+    void testDeleteMessage_ShouldThrowExceptionForNonExistentMessage() {
+        StepVerifier.create(dummyPecService.deleteMessage("non-existent-id"))
+                    .expectError(IllegalArgumentException.class)
+                    .verify();
+    }
+}

--- a/src/test/java/it/pagopa/pn/template/service/DummyPecServiceGetMessageCountTest.java
+++ b/src/test/java/it/pagopa/pn/template/service/DummyPecServiceGetMessageCountTest.java
@@ -1,0 +1,60 @@
+package it.pagopa.pn.template.service;
+
+import it.pagopa.pn.template.dto.PecInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import reactor.test.StepVerifier;
+
+import java.util.UUID;
+
+@SpringBootTest(classes = DummyPecTestApplication.class)
+class DummyPecServiceGetMessageCountTest {
+    @Autowired
+    private DummyPecService dummyPecService;
+
+    @BeforeEach
+    void setUp() {
+        dummyPecService = new DummyPecService(new DummyPecServiceUtil());
+        dummyPecService.getPecMap().clear();
+    }
+
+    @Test
+    void testGetMessageCount_ShouldReturnCorrectCount() {
+        for (int i = 0; i < 5; i++) {
+            String messageId = UUID.randomUUID().toString();
+            dummyPecService.getPecMap().put(messageId, PecInfo.builder()
+                                                              .messageId(messageId)
+                                                              .build());
+        }
+
+        StepVerifier.create(dummyPecService.getMessageCount())
+                    .expectNext(5)
+                    .verifyComplete();
+    }
+
+    @Test
+    void testGetMessageCount_ShouldReturnZeroForEmptyMap() {
+        StepVerifier.create(dummyPecService.getMessageCount())
+                    .expectNext(0)
+                    .verifyComplete();
+    }
+
+
+    @Test
+    void testGetMessageCount_ShouldReflectDynamicChanges() {
+        dummyPecService.getPecMap().put("msg1", PecInfo.builder().messageId("msg1#id").build());
+        dummyPecService.getPecMap().put("msg2", PecInfo.builder().messageId("msg2#id").build());
+
+        StepVerifier.create(dummyPecService.getMessageCount())
+                    .expectNext(2)
+                    .verifyComplete();
+
+        dummyPecService.getPecMap().put("msg3", PecInfo.builder().messageId("msg3#id").build());
+
+        StepVerifier.create(dummyPecService.getMessageCount())
+                    .expectNext(3)
+                    .verifyComplete();
+    }
+}

--- a/src/test/java/it/pagopa/pn/template/service/DummyPecServiceGetUnreadMessagesTest.java
+++ b/src/test/java/it/pagopa/pn/template/service/DummyPecServiceGetUnreadMessagesTest.java
@@ -19,6 +19,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 
@@ -106,7 +107,7 @@ class DummyPecServiceGetUnreadMessagesTest {
                 .build();
 
         // Act
-        byte[] mimeBytes = dummyPecServiceUtil.convertPecInfoToBytes(pecInfo);
+        byte[] mimeBytes = dummyPecServiceUtil.convertPecInfoToBytes(Map.entry("test-message-id", pecInfo));
 
         // Assert
         MimeMessage mimeMessage = new MimeMessage(Session.getInstance(new Properties()), new ByteArrayInputStream(mimeBytes));

--- a/src/test/java/it/pagopa/pn/template/service/DummyPecServiceGetUnreadMessagesTest.java
+++ b/src/test/java/it/pagopa/pn/template/service/DummyPecServiceGetUnreadMessagesTest.java
@@ -1,0 +1,71 @@
+package it.pagopa.pn.template.service;
+
+import it.pagopa.pn.template.dto.PecInfo;
+import it.pagopa.pn.template.type.PecType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import reactor.test.StepVerifier;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes = DummyPecTestApplication.class)
+class DummyPecServiceGetUnreadMessagesTest {
+    public static final int TOTAL_MSG = 10;
+    public static final int EXPECTED_UNREAD_MSG = 4;
+    public static final int LIMIT_UNREAD = 4;
+
+    @Autowired
+    private DummyPecService dummyPecService;
+
+    @BeforeEach
+    void setUp() {
+        // Popola la mappa con 5 messaggi di esempio
+        for (int i = 0; i < TOTAL_MSG; i++) {
+            String messageId = UUID.randomUUID().toString();
+            dummyPecService.getPecMap()
+                           .put(messageId,
+                                PecInfo.builder()
+                                       .messageId(messageId)
+                                       .receiverAddress("test" + i + "@receiver.com")
+                                       .subject("Subject " + i)
+                                       .from("test" + i + "@sender.com")
+                                       .pecType(isRead(i) ? PecType.ACCETTAZIONE : PecType.CONSEGNA)
+                                       .read(isRead(i)) // Solo i messaggi con indice dispari sono non letti
+                                       .build());
+        }
+    }
+
+    private boolean isRead(int i) {
+        return i % 2 == 0;
+    }
+
+    @Test
+    void testGetUnreadMessages_ShouldReturnUnreadMessagesAsBytes() {
+        StepVerifier.create(dummyPecService.getUnreadMessages(LIMIT_UNREAD)).assertNext(response -> {
+            assertEquals(EXPECTED_UNREAD_MSG, response.getNumOfMessages());
+
+            // Verifica che ogni messaggio sia rappresentato come byte[]
+            List<byte[]> messages = response.getPnListOfMessages().getMessages();
+            assertEquals(EXPECTED_UNREAD_MSG, messages.size());
+            messages.forEach(Assertions::assertNotNull);
+        }).verifyComplete();
+    }
+
+    @Test
+    void testGetUnreadMessages_ShouldHandleNoUnreadMessages() {
+        dummyPecService.getPecMap().values().forEach(message -> message.setRead(true));
+
+        StepVerifier.create(dummyPecService.getUnreadMessages(LIMIT_UNREAD))
+                    .assertNext(response -> {
+                        assertEquals(0, response.getNumOfMessages());
+                        assertTrue(response.getPnListOfMessages().getMessages().isEmpty());
+                    })
+                    .verifyComplete();
+    }
+}

--- a/src/test/java/it/pagopa/pn/template/service/DummyPecServiceGetUnreadMessagesTest.java
+++ b/src/test/java/it/pagopa/pn/template/service/DummyPecServiceGetUnreadMessagesTest.java
@@ -7,6 +7,7 @@ import jakarta.mail.Session;
 import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeMultipart;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -82,15 +83,27 @@ class DummyPecServiceGetUnreadMessagesTest {
     }
 
     @Test
-    void testConvertPecInfoToBytes_ShouldIncludeDaticertAttachment() throws Exception {
+    void testConvertPecInfoToBytes_ShouldIncludeDaticertAccettazioneAttachment() throws Exception {
+        String daticert = testConvertPecInfoToBytes(PecType.ACCETTAZIONE);
+        assertTrue(daticert.contains("<postacert tipo=\"accettazione\""));
+    }
+    @Test
+    void testConvertPecInfoToBytes_ShouldIncludeDaticertConsegnaAttachment() throws Exception {
+        String daticert = testConvertPecInfoToBytes(PecType.CONSEGNA);
+        assertTrue(daticert.contains("<postacert tipo=\"avvenuta-consegna\""));
+    }
+
+    // Converte un PecInfo in un daticert. Restituisce il daticert sottoforma di stringa
+    String testConvertPecInfoToBytes(PecType pecType) throws IOException, MessagingException {
         // Arrange
         PecInfo pecInfo = PecInfo.builder()
-                                 .messageId("test-message-id")
-                                 .from("sender@test.com")
-                                 .receiverAddress("receiver@test.com")
-                                 .subject("Test Subject")
-                                 .replyTo("reply@test.com")
-                                 .build();
+                .messageId("test-message-id")
+                .from("sender@test.com")
+                .receiverAddress("receiver@test.com")
+                .subject("Test Subject")
+                .replyTo("reply@test.com")
+                .pecType(pecType)
+                .build();
 
         // Act
         byte[] mimeBytes = dummyPecServiceUtil.convertPecInfoToBytes(pecInfo);
@@ -108,8 +121,7 @@ class DummyPecServiceGetUnreadMessagesTest {
 
         // Leggi il contenuto dello stream come stringa
         var inputStream = datiCertPart.getInputStream();
-        String content = new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
-        assertTrue(content.contains("<postacert tipo=\"avvenuta-consegna\""));
+        return new String(inputStream.readAllBytes(), StandardCharsets.UTF_8);
     }
 
 }

--- a/src/test/java/it/pagopa/pn/template/service/DummyPecServiceMarkMessageAsReadTest.java
+++ b/src/test/java/it/pagopa/pn/template/service/DummyPecServiceMarkMessageAsReadTest.java
@@ -1,0 +1,47 @@
+package it.pagopa.pn.template.service;
+
+import it.pagopa.pn.template.dto.PecInfo;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import reactor.test.StepVerifier;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringBootTest(classes = DummyPecTestApplication.class)
+class DummyPecServiceMarkMessageAsReadTest {
+    @Autowired
+    private DummyPecService dummyPecService;
+
+    @Test
+    void testMarkMessageAsRead_ShouldMarkMessageAsRead() {
+        String messageID = "test-message-id";
+        dummyPecService.getPecMap().put(messageID, PecInfo.builder()
+                                                          .messageId(messageID)
+                                                          .read(false)
+                                                          .build());
+
+        StepVerifier.create(dummyPecService.markMessageAsRead(messageID))
+                    .verifyComplete();
+
+        assertTrue(dummyPecService.getPecMap().get(messageID).isRead());
+    }
+
+    @Test
+    void testMarkMessageAsRead_ShouldThrowExceptionForNullMessageID() {
+        StepVerifier.create(dummyPecService.markMessageAsRead(null))
+                    .expectError(IllegalArgumentException.class)
+                    .verify();
+
+        StepVerifier.create(dummyPecService.markMessageAsRead(""))
+                    .expectError(IllegalArgumentException.class)
+                    .verify();
+    }
+
+    @Test
+    void testMarkMessageAsRead_ShouldThrowExceptionForNonExistentMessage() {
+        StepVerifier.create(dummyPecService.markMessageAsRead("non-existent-id"))
+                    .expectError(IllegalArgumentException.class)
+                    .verify();
+    }
+}

--- a/src/test/java/it/pagopa/pn/template/service/DummyPecServiceSendMailTest.java
+++ b/src/test/java/it/pagopa/pn/template/service/DummyPecServiceSendMailTest.java
@@ -1,0 +1,72 @@
+package it.pagopa.pn.template.service;
+
+import it.pagopa.pn.template.dto.PecInfo;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import reactor.test.StepVerifier;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(classes = DummyPecTestApplication.class)
+class DummyPecServiceSendMailTest {
+    @Autowired
+    private DummyPecService dummyPecService;
+
+    @BeforeEach
+    void resetPecMap() {
+        dummyPecService.getPecMap().clear();
+    }
+
+    @Test
+    void testSendMail_ShouldInsertMessagesIntoMapAndReturnOriginalId() throws Exception {
+        // Arrange
+        byte[] message = DummyPecServiceTestUtil.createMimeMessageAsBytes("Test Subject", "test@sender.com", "test@receiver.com");
+
+        // Act
+        StepVerifier.create(dummyPecService.sendMail(message))
+                    .assertNext(originalMessageId -> {
+                        // Verifica che l'ID originale sia restituito
+                        assertNotNull(originalMessageId);
+
+                        // Verifica che nella mappa siano presenti solo 2 messaggi
+                        Map<String, PecInfo> pecMap = dummyPecService.getPecMap();
+                        assertEquals(2, pecMap.size());
+
+                        // Verifica i dettagli dei messaggi
+                        for (PecInfo pecInfo : pecMap.values()) {
+                            assertEquals("Test Subject", pecInfo.getSubject());
+                            assertEquals("test@receiver.com", pecInfo.getReceiverAddress());
+                            assertEquals("test@sender.com", pecInfo.getFrom());
+                            assertFalse(pecInfo.isRead());
+                        }
+                    })
+                    .verifyComplete();
+    }
+
+
+    @Test
+    void testSendMail_ShouldHandleNullMessage() {
+        // Arrange
+        byte[] message = null;
+
+        // Act & Assert
+        StepVerifier.create(dummyPecService.sendMail(message))
+                    .expectError(NullPointerException.class)
+                    .verify();
+    }
+
+    @Test
+    void testSendMail_ShouldHandleInvalidMimeMessage() {
+        // Arrange
+        byte[] invalidMessage = "invalid message".getBytes();
+
+        // Act & Assert
+        StepVerifier.create(dummyPecService.sendMail(invalidMessage))
+                    .expectError(Exception.class)
+                    .verify();
+    }
+}

--- a/src/test/java/it/pagopa/pn/template/service/DummyPecServiceTestConfiguration.java
+++ b/src/test/java/it/pagopa/pn/template/service/DummyPecServiceTestConfiguration.java
@@ -1,0 +1,18 @@
+package it.pagopa.pn.template.service;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+@TestConfiguration
+public class DummyPecServiceTestConfiguration {
+
+    @Bean
+    public DummyPecService dummyPecService() {
+        return new DummyPecService(new DummyPecServiceUtil());
+    }
+
+    @Bean
+    public DummyPecServiceUtil dummyPecServiceUtil() {
+        return new DummyPecServiceUtil();
+    }
+}

--- a/src/test/java/it/pagopa/pn/template/service/DummyPecServiceTestUtil.java
+++ b/src/test/java/it/pagopa/pn/template/service/DummyPecServiceTestUtil.java
@@ -1,0 +1,41 @@
+package it.pagopa.pn.template.service;
+
+import jakarta.mail.Session;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeBodyPart;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeMultipart;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.util.Properties;
+
+@Service
+public class DummyPecServiceTestUtil {
+
+    public static byte[] createMimeMessageAsBytes(String subject, String from, String to) throws Exception {
+        Session session = Session.getDefaultInstance(new Properties());
+
+        // create a new MimeMessage
+        MimeMessage mimeMessage = new MimeMessage(session);
+        mimeMessage.setSubject(subject);
+        mimeMessage.setFrom(new InternetAddress(from));
+        mimeMessage.addRecipient(MimeMessage.RecipientType.TO, new InternetAddress(to));
+
+        // add simple body content
+        MimeBodyPart bodyPart = new MimeBodyPart();
+        bodyPart.setText("This is a body simple text message");
+
+        // build the message with body
+        MimeMultipart multipart = new MimeMultipart();
+        multipart.addBodyPart(bodyPart);
+        mimeMessage.setContent(multipart);
+
+        // write the message to a byte array
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        mimeMessage.writeTo(outputStream);
+
+        return outputStream.toByteArray();
+    }
+}
+

--- a/src/test/java/it/pagopa/pn/template/service/DummyPecTestApplication.java
+++ b/src/test/java/it/pagopa/pn/template/service/DummyPecTestApplication.java
@@ -1,0 +1,7 @@
+package it.pagopa.pn.template.service;
+
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class DummyPecTestApplication {
+}


### PR DESCRIPTION
Introduced DummyPecService to simulate PEC service operations, including sending, reading, and deleting messages. Added comprehensive unit tests for service methods and utilities. Updated the pom.xml with necessary dependencies for functionality and parsing email messages.